### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/docs.dezh.tech/security/code-scanning/1](https://github.com/dezh-tech/docs.dezh.tech/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job, explicitly setting the `contents` permission to `read`. This ensures that the `GITHUB_TOKEN` used in the `build` job has only the minimal permissions required to perform its tasks. The `deploy` job already has an appropriate `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
